### PR TITLE
Graphic files

### DIFF
--- a/advencal/admin.py
+++ b/advencal/admin.py
@@ -29,8 +29,8 @@ def questsed():
             db.session.commit()
             return redirect(url_for('questsed'))
 
-        elif 'upload_graffile' in request.files:
-            f = request.files['upload_graffile']
+        elif 'upload_asset' in request.files:
+            f = request.files['upload_asset']
             f.save(os.path.join(
                     './advencal/static/quests/',
                     secure_filename(f.filename)
@@ -42,13 +42,13 @@ def questsed():
     if request.method == 'GET':
         users = User.query.all()
         days = Day.query.order_by(Day.day_no).all()
-        graffiles = os.listdir('./advencal/static/quests/')
+        assets = os.listdir('./advencal/static/quests/')
         return render_template(
                 'quests.html.j2',
                 users=users,
                 date_today=date_today,
                 days=days,
-                graffiles=graffiles
+                assets=assets
                 )
 
 

--- a/advencal/admin.py
+++ b/advencal/admin.py
@@ -37,6 +37,13 @@ def questsed():
                     ))
             return redirect(url_for('questsed'))
 
+        elif 'asset_del' in request.form:
+            os.remove(os.path.join(
+                    './advencal/static/quests/',
+                    secure_filename(request.form['asset_del'])
+                    ))
+            return redirect(url_for('questsed'))
+
         return redirect(url_for('index'))
 
     if request.method == 'GET':

--- a/advencal/templates/base.html.j2
+++ b/advencal/templates/base.html.j2
@@ -103,11 +103,9 @@
       text = decodeURI(text)
     }
     navigator.clipboard.writeText(text).then(() => {
-      console.log('ok')
-      console.log(text)
+      /* clipboard successfully set */
       }, () => {
-      console.log('dupa')
-      console.log(text)
+      /* clipboard write failed */
     });
   }
   </script>

--- a/advencal/templates/base.html.j2
+++ b/advencal/templates/base.html.j2
@@ -94,6 +94,24 @@
   <script src="https://printjs-4de6.kxcdn.com/print.min.js"></script>
   <!-- JavaScript Bundle with Popper -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-OERcA2EqjJCMA+/3y+gxIOqMEjwtxJY7qPCqsdltbNJuaOe923+mo//f6V8Qbsw3" crossorigin="anonymous"></script>
+
+  <script type="text/javascript">
+  // Copy to clipboard rewritten in pure js and using
+  // new clipboard API.
+  function copyToClipboard(text, decode=false) {
+    if(decode){
+      text = decodeURI(text)
+    }
+    navigator.clipboard.writeText(text).then(() => {
+      console.log('ok')
+      console.log(text)
+      }, () => {
+      console.log('dupa')
+      console.log(text)
+    });
+  }
+  </script>
+
   {% endblock %}
 </body>
 </html>

--- a/advencal/templates/quests.html.j2
+++ b/advencal/templates/quests.html.j2
@@ -57,7 +57,6 @@
 
 <fieldset class="form-group border rounded-3 p-3">
     <legend class="float-none w-auto px-3">Biblioteka obrazków</legend>
-    <!--TODO: miejsce na przycisk Dodaj nowy obrazek-->
     <form action ="/questsed" method = "POST" enctype = "multipart/form-data">
         <div class="input-group mb-3">
             <input type="file" class="form-control" id="upload_asset" name="upload_asset" aria-describedby="upload_asset" aria-label="Załaduj">
@@ -69,7 +68,7 @@
         <thead>
             <th scope="col">Grafika</th>
             <th scope="col">Link</th>
-            <th scope="col"></th> <!--TODO: miejsce na przycisk kopiowania linka niestety javascript-->
+            <th scope="col"></th>
             <th scope="col"></th>
         </thead>
         <tbody>

--- a/advencal/templates/quests.html.j2
+++ b/advencal/templates/quests.html.j2
@@ -77,7 +77,7 @@
             <tr>
                 <td style="width: 50%"><img class="img-fluid" src="/static/quests/{{ item }}" style="max-height: 400px"></td>
                 <td style="width: 100%" class="align-middle">&lt;img class="img-fluid" src="/static/quests/{{ item }}"&gt;</td>
-                <td class="align-middle"><form action="" method="POST"><button class="btn btn-outline-info btn-sm" type="submit" name="graffile_copylink" value="{{ item }}"><i class="bi bi-link-45deg"></i></button></form></td>
+                <td class="align-middle"><button class="btn btn-outline-info btn-sm" onclick="copyToClipboard('%3Cimg%20class=%22img-fluid%22%20src=%22/static/quests/{{ item }}%22%3E', true)"><i class="bi bi-link-45deg"></i></button></td>
                 <td class="align-middle"><form action="" method="POST"><button class="btn btn-outline-danger btn-sm" type="submit" name="graffile_del" value="{{ item }}"><i class="bi bi-trash-fill"></i></button></form></td>   
             </tr>
             {%- endfor %}

--- a/advencal/templates/quests.html.j2
+++ b/advencal/templates/quests.html.j2
@@ -60,8 +60,8 @@
     <!--TODO: miejsce na przycisk Dodaj nowy obrazek-->
     <form action ="/questsed" method = "POST" enctype = "multipart/form-data">
         <div class="input-group mb-3">
-            <input type="file" class="form-control" id="upload_graffile" name="upload_graffile" aria-describedby="upload_graffile" aria-label="Załaduj">
-            <button class="btn btn-outline-success" type="submit" id="upload_graffile">Załaduj</button>
+            <input type="file" class="form-control" id="upload_asset" name="upload_asset" aria-describedby="upload_asset" aria-label="Załaduj">
+            <button class="btn btn-outline-success" type="submit" id="upload_asset">Załaduj</button>
 
         </div>
     </form> 
@@ -73,12 +73,12 @@
             <th scope="col"></th>
         </thead>
         <tbody>
-            {%- for item in graffiles %}
+            {%- for item in assets %}
             <tr>
                 <td style="width: 50%"><img class="img-fluid" src="/static/quests/{{ item }}" style="max-height: 400px"></td>
                 <td style="width: 100%" class="align-middle">&lt;img class="img-fluid" src="/static/quests/{{ item }}"&gt;</td>
                 <td class="align-middle"><button class="btn btn-outline-info btn-sm" onclick="copyToClipboard('%3Cimg%20class=%22img-fluid%22%20src=%22/static/quests/{{ item }}%22%3E', true)"><i class="bi bi-link-45deg"></i></button></td>
-                <td class="align-middle"><form action="" method="POST"><button class="btn btn-outline-danger btn-sm" type="submit" name="graffile_del" value="{{ item }}"><i class="bi bi-trash-fill"></i></button></form></td>   
+                <td class="align-middle"><form action="" method="POST"><button class="btn btn-outline-danger btn-sm" type="submit" name="asset_del" value="{{ item }}"><i class="bi bi-trash-fill"></i></button></form></td>   
             </tr>
             {%- endfor %}
         </tbody>

--- a/advencal/templates/users.html.j2
+++ b/advencal/templates/users.html.j2
@@ -162,18 +162,6 @@ Pomocny URL: https://adwent.jutrzenka.mlerp.pl</textarea>
         </script>
 
         <script type="text/javascript">
-          // Copy to clipboard rewritten in pure js and using
-          // new clipboard API.
-          function copyToClipboard(text) {
-            navigator.clipboard.writeText(text).then(() => {
-              /* clipboard successfully set */
-              }, () => {
-              /* clipboard write failed */
-            });
-          }
-        </script>
-
-        <script type="text/javascript">
           // Populate change password modal with values from button
           // that triggered the modal. 
           const changePassModal = document.getElementById('changepass_modal')


### PR DESCRIPTION
In this PR:
- variable names were changed to more general (as it is possible to upload and use files other than graphic)
- copy to clipboard JS function was moved to base template
- copy to clipboard JS function has now optional Boolean parameter `decode` that, when set, decodes (decodeURI) passed text, as it's insane to try and escape all quotes and angle brackets in HTML/JS
- copy link and delete asset buttons now work as expected
- fixes #10 