### PR TITLE
Fix change pass

### DIFF
--- a/advencal/basic/basic.py
+++ b/advencal/basic/basic.py
@@ -141,7 +141,7 @@ def change_pass():
             commit(db.session)
 
             flash(_('Hasło zmienione poprawnie'), 'success')
-            return redirect(url_for('basic.index'))
+            return redirect(url_for('basic.logout'))
 
         flash(_('Hasło nie zostało zmienione'), 'warning')
 

--- a/tests/functional/test_change_pass.py
+++ b/tests/functional/test_change_pass.py
@@ -44,7 +44,7 @@ def test_change_pass_new_password_not_identical(user_client, init_database):
     assert 'Nowe hasła nie są jednakowe' in response.data.decode('utf-8')
 
 
-def test_chang_epass_correct(user_client, init_database):
+def test_change_pass_correct(user_client, init_database):
     """
     GIVEN a Flask app configured for testing
     WHEN the '/change_pass' page is requested (POST) with correct data


### PR DESCRIPTION
Fixed:
- now session ends after successful password change, so "remember me" cookie is cleared
- typo in test name